### PR TITLE
refs 28412 - allow configuration of executor_signal_escalation_timeout 

### DIFF
--- a/include/mesos/mesos.proto
+++ b/include/mesos/mesos.proto
@@ -366,6 +366,7 @@ message SlaveInfo {
   // TODO(joerg84): Remove checkpoint field as with 0.22.0
   // slave checkpointing is enabled for all slaves (MESOS-2317).
   optional bool checkpoint = 7 [default = false];
+  optional string executor_signal_escalation_timeout = 9;
 }
 
 

--- a/src/launcher/executor.cpp
+++ b/src/launcher/executor.cpp
@@ -97,6 +97,7 @@ public:
   {
     cout << "Registered executor on " << slaveInfo.hostname() << endl;
     driver = _driver;
+    setEscalationTimeout(slaveInfo);
   }
 
   void reregistered(
@@ -104,6 +105,17 @@ public:
       const SlaveInfo& slaveInfo)
   {
     cout << "Re-registered executor on " << slaveInfo.hostname() << endl;
+    setEscalationTimeout(slaveInfo);
+  }
+
+  void setEscalationTimeout(const SlaveInfo& slaveInfo){
+    // override with slave configuration
+    const string& timeout = slaveInfo.executor_signal_escalation_timeout();
+    Try<Duration> duration = Duration::parse(timeout);
+    if (duration.isSome()){
+      escalationTimeout = duration.get();
+    }
+    // future: override with task level configuration
   }
 
   void disconnected(ExecutorDriver* driver) {}

--- a/src/slave/flags.cpp
+++ b/src/slave/flags.cpp
@@ -166,6 +166,13 @@ mesos::internal::slave::Flags::Flags()
       "to shut down (e.g., 60secs, 3mins, etc)",
       EXECUTOR_SHUTDOWN_GRACE_PERIOD);
 
+  add(&Flags::executor_signal_escalation_timeout,
+      "executor_signal_escalation_timeout",
+      "Amount of time to wait for an executor\n"
+      "to shut down a task before considering it hung and\n"
+      "sending KILL signal (e.g., 60secs, 3mins, etc)",
+      EXECUTOR_SIGNAL_ESCALATION_TIMEOUT);
+
   add(&Flags::gc_delay,
       "gc_delay",
       "Maximum amount of time to wait before cleaning up\n"

--- a/src/slave/flags.hpp
+++ b/src/slave/flags.hpp
@@ -59,6 +59,7 @@ public:
   Option<JSON::Object> executor_environment_variables;
   Duration executor_registration_timeout;
   Duration executor_shutdown_grace_period;
+  Duration executor_signal_escalation_period;
   Duration gc_delay;
   double gc_disk_headroom;
   Duration disk_watch_interval;

--- a/src/slave/slave.cpp
+++ b/src/slave/slave.cpp
@@ -380,6 +380,7 @@ void Slave::initialize()
   info.mutable_attributes()->CopyFrom(attributes);
   // Checkpointing of slaves is always enabled.
   info.set_checkpoint(true);
+  info.set_executor_signal_escalation_timeout(stringify(flags.executor_signal_escalation_timeout));
 
   LOG(INFO) << "Slave hostname: " << info.hostname();
   // Checkpointing of slaves is always enabled.


### PR DESCRIPTION
This is for use in Executor when processes really need more time to handle shutdown before KILL is sent.
